### PR TITLE
refactor: Omit tables in code preview

### DIFF
--- a/src/web-component-docs.js
+++ b/src/web-component-docs.js
@@ -67,7 +67,7 @@ function webComponentDocs(hook) {
     // Wrap tables for responsive horizontal scrolling
     //
     const content = document.querySelector(".content");
-    const tables = [...content.querySelectorAll("table")];
+    const tables = [...content.querySelectorAll("table.metadata")];
 
     tables.map((table) => {
       table.outerHTML = `


### PR DESCRIPTION
# What does it do

Omits `<table>` elements in a code preview from being rendered with metadata element wrappers and styles.

# How does it do it

Determines if a table is in a `.code-preview` wrapper. If so, omit wrapping with a `component-meta-table` .

# Notes

**Before:**
<img width="1425" alt="Screenshot 2023-04-27 at 3 59 37 PM" src="https://user-images.githubusercontent.com/104786995/235001391-1fdcc426-1852-4732-b6a2-725426236922.png">

**After:**
<img width="1434" alt="Screenshot 2023-04-27 at 4 00 38 PM" src="https://user-images.githubusercontent.com/104786995/235001425-16ed7c17-3906-47a5-a06e-900bc7ffa229.png">
