### PR TITLE
feat: Support deprecated property display

### DIFF
--- a/docs/component-dist/custom-elements.json
+++ b/docs/component-dist/custom-elements.json
@@ -154,6 +154,7 @@
               },
               "default": "\"medium\"",
               "description": "The button's size.",
+              "deprecated": "true",
               "attribute": "size",
               "reflects": true
             },
@@ -292,6 +293,7 @@
               },
               "default": "\"medium\"",
               "description": "The button's size.",
+              "deprecated": "true",
               "fieldName": "size"
             },
             {

--- a/src/lib/metadata.js
+++ b/src/lib/metadata.js
@@ -24,7 +24,7 @@ function renderPropertiesTable(props) {
       <tbody>
         ${props
           .map((prop) => {
-            return `<tr>
+            return `<tr ${prop.deprecated ? "class='row-deprecated'" : ""}>
                 <th scope="row">
                   <code>${prop.name}</code>
                   ${
@@ -35,10 +35,13 @@ function renderPropertiesTable(props) {
                       : ``
                   }
                 </th>
-                <td>${prop.description.replace(
-                  /`(.*?)`/g,
-                  "<code>$1</code>"
-                )}</td>
+                <td>
+                ${
+                  prop.deprecated
+                    ? '<span class="deprecated">Deprecated.</span>'
+                    : ""
+                }
+                ${prop.description.replace(/`(.*?)`/g, "<code>$1</code>")}</td>
                 <td><code>${prop.type.text.replace(/^\| /m, "")}</code></td>
                 <td>${
                   prop.default ? `<code>${prop.default}</code>` : "&ndash;"

--- a/src/web-component-docs.css
+++ b/src/web-component-docs.css
@@ -4,7 +4,7 @@
 
 .component-status::before {
   display: inline-block;
-  content: "";
+  content: '';
   margin-right: 0.25rem;
   width: 0.6rem;
   height: 0.6rem;
@@ -31,6 +31,14 @@
   overflow: auto;
   width: 100%;
   min-width: 700px;
+}
+
+.component-meta-table tr.row-deprecated th code {
+  text-decoration: line-through;
+}
+
+.component-meta-table .deprecated {
+  font-weight: bold;
 }
 
 .markdown-section .component-method-signature {


### PR DESCRIPTION
Adds a styling hook and includes the term "Deprecated." in the description of properties/attributes marked as `deprecated` in the Custom Elements Manifest. 